### PR TITLE
update rank's Q3 question to match the answer

### DIFF
--- a/templates/ranking/3.html.tera
+++ b/templates/ranking/3.html.tera
@@ -4,7 +4,7 @@
 {% block question %}
 
 <p>
-Each cat would like to know what percentage of cats weigh less than it
+Each cat would like to know what percentage of other cats weigh less than it
 <hr/>
 Return: name, weight, percent
 <br/>


### PR DESCRIPTION
The suggested answer using `percent_rank` doesn't answer the question as previously asked, not exactly.

> Each cat would like to know what percentage of cats weigh less than it

For a table like this:

```
postgres=# select * from foo;
 id | weight
----+--------
 12 |      1
 13 |      2
 14 |      3
 15 |      4
(4 rows)
```

The formulation which includes yourself as a cat suggests this answer:

```
 id | pct
----+-----
 12 |   0
 13 |  25
 14 |  50
 15 |  75
(4 rows)
```

But using percent_rank yields:

```
 id |  pct
----+--------
 12 |   0.00
 13 |  33.33
 14 |  66.67
 15 | 100.00
(4 rows)
```

That only makes sense if you don't include yourself in the result set.